### PR TITLE
Fix issue with mobile logo visible on desktop

### DIFF
--- a/Magento_Theme/web/css/source/_extend.less
+++ b/Magento_Theme/web/css/source/_extend.less
@@ -26,7 +26,7 @@
 }
 
 .media-width(@extremum, @break) when (@extremum = 'min') and (@break = @screen__s) {
-    .logo {
+    .header .logo {
         display: block;
 
         &--mobile {


### PR DESCRIPTION
The specificity of the mobile styling included `.header {` that puts it at `0, 2, 0`. This `.header` wasn't in the desktop styles so even with the media query it was being overridden.

Adding in the same `.header` specificity brings the desktop styles up to over be able to override the mobile ones.