### PR TITLE
Fix issue with mobile logo always displaying

### DIFF
--- a/Magento_Theme/templates/html/header/logo.phtml
+++ b/Magento_Theme/templates/html/header/logo.phtml
@@ -27,17 +27,6 @@ $imgSrc = $customLogoUrl ? $block->getUrl() .'media/' . $customLogoUrl : $block-
 ?>
 <span data-action="toggle-nav" class="action nav-toggle"><span><?= $block->escapeHtml(__('Toggle Nav')) ?></span></span>
 
-<a
-    class="logo"
-    href="<?= $block->escapeUrl($block->getUrl('')) ?>"
-    title="<?= $block->escapeHtmlAttr($storeName) ?>"
-    aria-label="store logo">
-    <img src="<?= $block->escapeUrl($imgSrc) ?>"
-         title="<?= $block->escapeHtmlAttr($block->getLogoAlt()) ?>"
-         alt="<?= $block->escapeHtmlAttr($block->getLogoAlt()) ?>"
-    />
-</a>
-
 <?php if ($customMobileLogoUrl): ?>
     <a
         class="logo logo--mobile"
@@ -50,3 +39,14 @@ $imgSrc = $customLogoUrl ? $block->getUrl() .'media/' . $customLogoUrl : $block-
         />
     </a>
 <?php endif; ?>
+
+<a
+    class="logo"
+    href="<?= $block->escapeUrl($block->getUrl('')) ?>"
+    title="<?= $block->escapeHtmlAttr($storeName) ?>"
+    aria-label="store logo">
+    <img src="<?= $block->escapeUrl($imgSrc) ?>"
+         title="<?= $block->escapeHtmlAttr($block->getLogoAlt()) ?>"
+         alt="<?= $block->escapeHtmlAttr($block->getLogoAlt()) ?>"
+    />
+</a>

--- a/Magento_Theme/web/css/source/_extend.less
+++ b/Magento_Theme/web/css/source/_extend.less
@@ -5,8 +5,6 @@
 & when (@media-common = true) {
     .header {
         .logo {
-            display: none;
-
             img {
                 display: block;
                 max-width: 150px;
@@ -20,17 +18,21 @@
                     max-width:100px;
                     max-height:50px
                 }
+
+                + .logo {
+                    display: none;
+                }
             }
         }
     }
 }
 
 .media-width(@extremum, @break) when (@extremum = 'min') and (@break = @screen__s) {
-    .header .logo {
-        display: block;
+    .header .logo--mobile {
+        display: none;
 
-        &--mobile {
-            display: none;
+        + .logo {
+            display: block;
         }
     }
 }


### PR DESCRIPTION
Issue was that there was no checks to see if just a desktop image had been uploaded and therefore the mobile was always rendering.

Updated the order of the render so that mobile would appear first in the DOM and then we can use a next sibling selector to update the render state of the desktop accordingly.