### PR TITLE
Corrected breakpoint for mobile/desktop logo switch

### DIFF
--- a/Magento_Theme/web/css/source/_extend.less
+++ b/Magento_Theme/web/css/source/_extend.less
@@ -27,7 +27,7 @@
     }
 }
 
-.media-width(@extremum, @break) when (@extremum = 'min') and (@break = @screen__s) {
+.media-width(@extremum, @break) when (@extremum = 'min') and (@break = @screen__m) {
     .header .logo--mobile {
         display: none;
 

--- a/Magento_Theme/web/css/source/_extend.less
+++ b/Magento_Theme/web/css/source/_extend.less
@@ -28,7 +28,7 @@
 }
 
 .media-width(@extremum, @break) when (@extremum = 'min') and (@break = @screen__m) {
-    .header .logo--mobile {
+    .header.content .logo--mobile {
         display: none;
 
         + .logo {

--- a/theme.xml
+++ b/theme.xml
@@ -1,6 +1,6 @@
 <theme xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:noNamespaceSchemaLocation="urn:magento:framework:Config/etc/theme.xsd">
-    <title>Blue Finch Luma</title>
+    <title>BlueFinch Luma</title>
     <parent>Magento/luma</parent>
     <media>
         <preview_image>media/preview.jpg</preview_image>


### PR DESCRIPTION
The previous breakpoint showed the desktop logo too early while the mobile menu was still visible.

Updated to be the correct mobile/desktop switch point.